### PR TITLE
fix: Update availability condition to include equal comparison

### DIFF
--- a/routes/prodotti.js
+++ b/routes/prodotti.js
@@ -130,7 +130,7 @@ function createQuery(filters) {
 
     // disponibilita
     if (typeof filters.disponibilita !== 'undefined') {
-        conditions.push('p.disponibilita > ?');
+        conditions.push('p.disponibilita >= ?');
         params.push(filters.disponibilita);
     }
 


### PR DESCRIPTION
This pull request includes a small but important change to the `createQuery` function in the `routes/prodotti.js` file. The change modifies the condition for filtering product availability to include products with availability equal to the specified value, in addition to those with availability greater than the value.